### PR TITLE
Add dockerignore to reduce build context size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+client/node_modules
+resources
+env


### PR DESCRIPTION
We need to ignore `node_modules` and `resources` when sending the build context to docker daemon.