### PR TITLE
Chinaza/improve local workflow

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 
 FROM alpine:latest AS setup-venv
 WORKDIR /var/www/apache
-COPY scripts ./scripts
+COPY scripts/setup-venv.sh ./scripts/setup-venv.sh
 RUN apk add py3-pip python3 && sh ./scripts/setup-venv.sh
  
 FROM alpine:latest AS with-venv
@@ -14,6 +14,7 @@ RUN cat httpd-suffix.conf >> /etc/apache2/httpd.conf ; \
 WORKDIR /var/www/apache
 COPY --from=setup-venv /var/www/apache/env ./env
 COPY scripts ./scripts
+
 COPY manage.py ./manage.py
 COPY server ./server
 COPY client ./client
@@ -23,7 +24,7 @@ RUN . env/bin/activate && echo yes | python3 manage.py collectstatic
 
 USER root:root
 
-ENTRYPOINT [ "/bin/bash" ]
-CMD [ "-c", "httpd -D FOREGROUND" ]
+ENTRYPOINT [ "bash", "scripts/run-production.bash" ]
+
 EXPOSE 80
 EXPOSE 5432

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,7 +4,29 @@
 
 Install docker compose.
 
-## Commands
+## Running the production server
+
+In the 'docker' directory, run:
+
+```
+docker compose build
+docker compose up webserver
+```
+
+Access the page at `localhost:8080` in your browser.
+
+When you are done, use:
+
+```
+docker compose down
+```
+
+## Running the development server
+
+The development server is supposed to make the `edit -> update -> edit` feedback loop quicker.
+Basically, it listens for file updates in `server/` or `client/` and reloads relevant files when this happens.
+
+The development server assumes that you have installed webpack in the client nodejs package (this should be in the package.json).
 
 In the 'docker' directory, run:
 
@@ -13,9 +35,7 @@ docker compose build
 docker compose up webserver-local
 ```
 
-Access the page at `localhost:8080` in your browser.
-
-Whe1n you are done, use:
+When you are done, use:
 
 ```
 docker compose down

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,7 @@ In the 'docker' directory, run:
 
 ```
 docker compose build
-docker compose up
+docker compose up webserver-local
 ```
 
 Access the page at `localhost:8080` in your browser.
@@ -19,4 +19,13 @@ Whe1n you are done, use:
 
 ```
 docker compose down
+```
+
+## Debugging
+
+The `shell.sh` script will launch a shell in a running webserver.
+From there, you can run run migrations, use the Django shell and otherwise debug the local setup.
+
+```
+./scripts/shell.sh
 ```

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,20 +3,27 @@ services:
     image: postgres:14.5
     volumes:
       - sweng-db:/var/lib/postgresql/data
-    environment: &env
+    environment: &environment
       POSTGRES_HOST: ${POSTGRES_HOST:-database}
       POSTGRES_USER: ${POSTGRES_USER:-dev}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-dev}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}
       POSTGRES_DB: ${POSTGRES_DB:-database}
-  webserver:
+  webserver: &webserver
     build:
       context: ..
       dockerfile: docker/Dockerfile
-    environment: *env
+    environment: *environment
     ports:
       - 8080:80
     links:
         - database:database
+  webserver-local:
+    <<: *webserver
+    volumes:
+      - ../client:/var/www/apache/client:ro
+      - ../server:/var/www/apache/server:ro
+      - ../static:/var/www/apache/static:ro
+    entrypoint: [ "bash", "scripts/run-local.bash" ]
 volumes:
   sweng-db:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-DJANGO_PROJECT_ROOT="$(dirname $(dirname $(realpath $0)))"
-cd "$DJANGO_PROJECT_ROOT"
+# Make sure that this script is being executed in the project root.
+if [ ! -e manage.py ]
+then
+    echo You must execute this script in the root of the repository!
+    exit 1
+fi
+export DJANGO_PROJECT_ROOT="$(pwd)"
 # Source VENV
 source env/bin/activate
 # Add node binaries to PATH if they have not been added already. (if
 # they exist at all).
-([ -d client/node_modules ] && [[ $PATH =~ client/node_modules ]])\
+([ -d client/node_modules ] && [[ $PATH =~ client/node_modules ]]) \
     || PATH+=:$(realpath client/node_modules/.bin/)
 # Define manage function that automatically loads the models we
 # use. Use this instead of 'python3 mange.py'. When ran without any

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,35 +1,14 @@
 #!/bin/bash
-
-# You should invoke this script via:
-#
-#      . scripts/install.sh
-#
-# It should set up the project root directory for you.
-
 DJANGO_PROJECT_ROOT="$(dirname $(dirname $(realpath $0)))"
-alias pushdq='1>/dev/null pushd'
-alias popdq='1>/dev/null popd'
-
-pushdq "$DJANGO_PROJECT_ROOT"
-
-# Set up VENV if VENV does not already exist
-[ ! -d env ] && sh scripts/setup-venv.sh
-
+cd "$DJANGO_PROJECT_ROOT"
 # Source VENV
 source env/bin/activate
-
 # Add node binaries to PATH if they have not been added already.
-pushdq client
-[[ $PATH =~ client/node_modules ]] || PATH+=:$(npm bin)
-popdq
-
+[[ $PATH =~ client/node_modules ]] || PATH+=:$(realpath client/node_modules/.bin/)
 # Define manage function that automatically loads the models we
 # use. Use this instead of 'python3 mange.py'. When ran without any
 # arguments, launches the shell.
 manage() {
-    pushdq "$DJANGO_PROJECT_ROOT"
-    PYTHONSTARTUP=./scripts/managerc.py python3 manage.py "${@:-shell}"
-    popdq
+    (cd "$DJANGO_PROJECT_ROOT";
+     PYTHONSTARTUP=./scripts/managerc.py python3 manage.py "${@:-shell}")
 }
-
-popdq

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,8 +3,10 @@ DJANGO_PROJECT_ROOT="$(dirname $(dirname $(realpath $0)))"
 cd "$DJANGO_PROJECT_ROOT"
 # Source VENV
 source env/bin/activate
-# Add node binaries to PATH if they have not been added already.
-[[ $PATH =~ client/node_modules ]] || PATH+=:$(realpath client/node_modules/.bin/)
+# Add node binaries to PATH if they have not been added already. (if
+# they exist at all).
+([ -d client/node_modules ] && [[ $PATH =~ client/node_modules ]])\
+    || PATH+=:$(realpath client/node_modules/.bin/)
 # Define manage function that automatically loads the models we
 # use. Use this instead of 'python3 mange.py'. When ran without any
 # arguments, launches the shell.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -10,8 +10,8 @@ export DJANGO_PROJECT_ROOT="$(pwd)"
 source env/bin/activate
 # Add node binaries to PATH if they have not been added already. (if
 # they exist at all).
-([ -d client/node_modules ] && [[ $PATH =~ client/node_modules ]]) \
-    || PATH+=:$(realpath client/node_modules/.bin/)
+([ -d client/node_modules/.bin/ ] && [[ ! $PATH =~ client/node_modules ]]) \
+    && PATH+=:$(realpath client/node_modules/.bin/)
 # Define manage function that automatically loads the models we
 # use. Use this instead of 'python3 mange.py'. When ran without any
 # arguments, launches the shell.

--- a/scripts/on-change.sh
+++ b/scripts/on-change.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+. scripts/install.sh
+
+case "$1/$2" in
+    *node_modules*)
+        # Ignore changes to node_modules
+        exit 1
+        ;;
+    *.py|*.js|*.html|*.css)
+        # Copy updated static files
+        echo yes | python3 manage.py collectstatic
+        # Recompile javascript bundle
+        cd client; webpack --mode development
+        # Restart httpd
+        httpd -k restart
+        ;;
+esac

--- a/scripts/run-local.bash
+++ b/scripts/run-local.bash
@@ -1,0 +1,3 @@
+#!/bin/bash
+httpd -k start
+inotifyd /var/www/apache/scripts/on-change.sh server:c client:c

--- a/scripts/run-production.bash
+++ b/scripts/run-production.bash
@@ -1,0 +1,2 @@
+#!/bin/bash
+httpd -k start -D FOREGROUND

--- a/scripts/shell.sh
+++ b/scripts/shell.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#Executing this will launch a shell in a running webserver container
+#that you started using 'docker compose up webserver-local'. It will
+#have the node binary locations placed in PATH and the VENV activation
+#script soruced.
+# 
+# Example Usage:
+#  > sh scripts/shell.sh
+#  $ (env) ....
+container=$(docker container list | awk '/webserver-local/ { print $1 }')
+docker container exec -it $container bash -c '. scripts/install.sh && exec bash -i'


### PR DESCRIPTION
- Fixes bug in `install.sh` caused by `$0` not being a file in all shells, and other assumptions about shells.
- Only copy setup-venv.sh in the first build stage to avoid needless recompilation when new scripts are added.
- Introduces `webserver-local` service which hot-reloads when you save files.
- Add `webserver-local` to README.