### PR TITLE
Bug: Carousel TextBox autoresize

### DIFF
--- a/client/src/components/Carousel.module.css
+++ b/client/src/components/Carousel.module.css
@@ -7,7 +7,6 @@
         display: flex;
         flex-direction: column;
         padding: 4rem;
-        padding-bottom: 0;
         gap: 2rem;
     }
 

--- a/client/src/components/TextBox.js
+++ b/client/src/components/TextBox.js
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react'
+import React, { useState, useRef, useEffect } from 'react'
 import useAutosizeTextArea from '../hooks/useAutosizeTextArea'
 import { Button } from './Button'
 import styles from './TextBox.module.css'
@@ -10,7 +10,8 @@ export const TextBox = ({
     onChangeInput,
 
 }) => {
-  const textAreaRef = useRef()
+    
+    const textAreaRef = useRef()
 
     useAutosizeTextArea(textAreaRef.current, content) 
 
@@ -24,8 +25,6 @@ export const TextBox = ({
               onChange={(e) => onChangeInput(e, id)} 
               placeHolder="Start typing"
               ref={textAreaRef}
-              rows={10} // this is the initial default value for the text box, 
-                          // it's a fixed amount of rows to display until the user makes an action, ie.clicks the box and types
             /> 
           </div>
         </div>

--- a/client/src/components/TextBox.js
+++ b/client/src/components/TextBox.js
@@ -10,8 +10,7 @@ export const TextBox = ({
     onChangeInput,
 
 }) => {
-
-    const textAreaRef = useRef()
+  const textAreaRef = useRef()
 
     useAutosizeTextArea(textAreaRef.current, content) 
 
@@ -25,12 +24,15 @@ export const TextBox = ({
               onChange={(e) => onChangeInput(e, id)} 
               placeHolder="Start typing"
               ref={textAreaRef}
-              rows={1}
+              rows={10} // this is the initial default value for the text box, 
+                          // it's a fixed amount of rows to display until the user makes an action, ie.clicks the box and types
             /> 
           </div>
         </div>
       </>
     )
+
+
 }
 
 export default TextBox

--- a/client/src/components/TextBox.module.css
+++ b/client/src/components/TextBox.module.css
@@ -6,12 +6,13 @@
         composes: TextBox;
         background-color: white;
     }
+      .paragraph-text-box {
+        composes: default-text-box;
+        padding: 2rem;
 
-        .paragraph-text-box {
-            composes: default-text-box;
-            padding: 2rem;
+    }
 
-        }
+      
 
 
 .textarea {

--- a/client/src/hooks/useAutosizeTextArea.js
+++ b/client/src/hooks/useAutosizeTextArea.js
@@ -1,17 +1,33 @@
-import { useEffect } from "react";
+import { useState, useEffect } from "react";
 
 const useAutosizeTextArea = (
   textAreaRef,
   value
 ) => {
 
+  const [onMount, setOnMount] = useState(false)
+  const [windowWidth, setWindowWidth] = useState(window.innerWidth)
+
+  const handleResize = () => {
+    setWindowWidth(window.innerWidth)
+  }
+
   useEffect(() => {
-    if (textAreaRef) {
+    setOnMount(true);
+    
+    window.addEventListener('resize', handleResize)
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, []);
+
+  useEffect(() => {
+    if (textAreaRef || onMount) {
       textAreaRef.style.height = "0px";
       const scrollHeight = textAreaRef.scrollHeight;
       textAreaRef.style.height = scrollHeight + "px";
     }
-  }, [textAreaRef, value]);
+  }, [textAreaRef, value, onMount, windowWidth]);
 };
 
 export default useAutosizeTextArea;


### PR DESCRIPTION
`Carousel.js` is supposed to display a scrollable area of `TextBox.js` components. These components should be auto-resizable as they adapt to the size of the paragraph and to the input of users.

This feature clashes with an old CSS issue that prevents input-like components (e.g.: input, textarea, ...) to have a autosize property, unlike normal non-editable text-tags.

To workaround this I created the custom hook `useAutosizeTextArea.js` that calls a `useEffect` to set the `height` of the textarea to `scrollHeight`.

**The bugs to be fixed are two:**
**- The resize is not applied at first render**
**- The resize is not applied when the window resizes**

Fixing this bug closes #43