### PR TITLE
Add tests for spell api and some document endpoints

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -1,3 +1,72 @@
-from django.test import TestCase
-
 # Create your tests here.
+from django.test import TestCase
+from django.urls import reverse
+from .models import *
+from .serializers import MistakeSerializer
+import json
+
+class ApiTester(TestCase):
+    documents = {
+        'Test Document 1' : {
+            'blocks' : [
+                "This sentence haas two incorrect wrds"
+            ]
+        },
+        'Test Document 2' : {
+            'blocks' : [
+                "This sentence haas two incorrect wrds",
+                "Ths senence haas four incorrect wrds"
+            ]
+        }
+    }
+
+    def test_document_has_correct_blocks(self):
+        document = self.create_document_from_template('Test Document 2')
+        document_blocks = self.client.get(reverse('api:get_document_blocks', args=(document.id,)))
+        data = json.loads(document_blocks.content)
+        self.assertEquals(len(data), 2)
+        self.assertEquals(data[0]['block_content'], self.documents['Test Document 2']['blocks'][0])
+        self.assertEquals(data[1]['block_content'], self.documents['Test Document 2']['blocks'][1])
+    
+    def create_document_from_template(self, title):
+        try:
+            template = self.documents[title]
+        except KeyError:
+            raise RuntimeError(f"Document with title '{title}' not found!!!")
+        document = Document.objects.create(title=title)
+        for order, block in enumerate(template['blocks']):
+            document.block_set.create(
+                block_content=block,
+                block_order=order
+            )
+        return document
+        
+    def test_mistake_class_serialisation_from_checked_document_blocks(self):
+        document = self.create_document_from_template('Test Document 1')
+        response = self.client.get(reverse('api:check_document_blocks', args=(document.id,)))
+        data = json.loads(response.content)
+        for block in data:
+            serializer = MistakeSerializer(data=block['mistakes'], many=True)
+            self.assertTrue(serializer.is_valid())
+
+    def test_mistake_class_serialisation_from_checked_document_blocks_with_multiple_blocks(self):
+        document = self.create_document_from_template('Test Document 2')
+        response = self.client.get(reverse('api:check_document_blocks', args=(document.id,)))
+        data = json.loads(response.content)
+        for block in data:
+            serializer = MistakeSerializer(data=block['mistakes'], many=True)
+            self.assertTrue(serializer.is_valid())
+            
+    def test_document_blocks_have_correct_mistakes(self):
+        document = self.create_document_from_template('Test Document 2')
+        response = self.client.get(reverse('api:check_document_blocks', args=(document.id,)))
+        data = response.data
+        self.assertEquals(len(data[0]['mistakes']), 2)
+        self.assertEquals(data[0]['mistakes'][0]['word'], 'haas')
+        self.assertEquals(data[0]['mistakes'][1]['word'], 'wrds')
+        self.assertEquals(len(data[1]['mistakes']), 4)
+        self.assertEquals(data[1]['mistakes'][0]['word'], 'Ths')
+        self.assertEquals(data[1]['mistakes'][1]['word'], 'senence')
+        self.assertEquals(data[1]['mistakes'][2]['word'], 'haas')
+        self.assertEquals(data[1]['mistakes'][3]['word'], 'wrds')
+


### PR DESCRIPTION
1) Add tests to ensure that the correct words are being picked out as incorrect by the spell checker
2) Add tests to ensure that serialisation of mistake class does not fail.
3) Add tests to ensure that document blocks are listed correctly by the API