### PR TITLE
Switch to svgr loader, require react runtime

### DIFF
--- a/client/babel.config.json
+++ b/client/babel.config.json
@@ -1,7 +1,7 @@
 {
     "presets" : [
         [ "@babel/env", { "targets" : { "node" : 10 } } ],
-        "@babel/react"
+        [ "@babel/react", { "runtime" : "automatic" } ],
     ],
     "plugins" : [
         "@babel/proposal-class-properties"

--- a/client/package.json
+++ b/client/package.json
@@ -14,7 +14,6 @@
     "react-router-dom": "^6.8.1",
     "react-scripts": "^5.0.1",
     "rsuite": "^5.26.1",
-    "svg-url-loader": "^8.0.0",
     "web-vitals": "^2.1.4",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1"
@@ -44,7 +43,9 @@
     ]
   },
   "devDependencies": {
+    "@svgr/webpack": "^6.5.1",
     "css-loader": "^6.7.3",
-    "style-loader": "^3.3.1"
+    "style-loader": "^3.3.1",
+    "url-loader": "^4.1.1"
   }
 }

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -19,12 +19,7 @@ module.exports = {
             },
             {
                 test: /\.svg$/,
-                use: [
-                    {
-                        loader: "svg-url-loader",
-                        options: { limit: 100000 }
-                    }
-                ]
+                use: ["@svgr/webpack", "url-loader"]
             }
         ]
     },


### PR DESCRIPTION
`svgr-loader` with `url-loader` will work fine for now for loading SVGs. Eventually all static files will be moved to `/project/client/static/client/...` and be served by apache.

React runtime has to be explicitly included post react 17. See here: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html.