### PR TITLE
Chinaza/bundle in docker for cd workflow

### DIFF
--- a/.github/workflows/docker_cd.yml
+++ b/.github/workflows/docker_cd.yml
@@ -36,5 +36,6 @@ jobs:
           file: ./docker/Dockerfile
           push: true
           tags: ${{ secrets.DOCKER_HUB_USERNAME }}/legal_spellcheck:${{ steps.env_task.outputs.tag }}
+          build-args: BUNDLE=production
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,31 @@
+# A string that is either 'local' or 'production'. If set to local,
+# the bundle will be copied from your local machine. If set to
+# production, it will be produced in docker. Note that this will
+# create a new docker image with each package.json update, which will
+# occupy hundreds of megabytes on your disk. This should only be used
+# in the CI/CD pipeline.
+ARG BUNDLE
 
-FROM alpine:latest AS setup-venv
+FROM scratch AS local-bundle
+COPY ./static/client/js/main.js /var/www/apache/static/client/js/main.js
+
+FROM node:latest AS production-bundle
+WORKDIR /var/www/apache/client
+COPY client .
+RUN npm install
+RUN PATH=$PATH:node_modules/.bin webpack
+
+# Depending on the BUNDLE argument, choose the local bundle or the
+# production bundle.
+FROM $BUNDLE-bundle as final-bundle
+
+From alpine:latest AS setup-venv
 WORKDIR /var/www/apache
 COPY scripts/setup-venv.sh ./scripts/setup-venv.sh
 RUN apk add py3-pip python3 && sh ./scripts/setup-venv.sh
  
 FROM alpine:latest AS with-venv
+ARG LSC_VARIANT=local
 RUN apk add apache2 apache2-mod-wsgi bash tzdata nodejs aspell aspell-en
 SHELL [ "/bin/bash", "-c" ]
 RUN sed -i 's/localhost\/htdocs//' /etc/apache2/httpd.conf
@@ -13,13 +34,14 @@ RUN cat httpd-suffix.conf >> /etc/apache2/httpd.conf ; \
     rm httpd-suffix.conf
 WORKDIR /var/www/apache
 COPY --from=setup-venv /var/www/apache/env ./env
+COPY --from=final-bundle \
+    /var/www/apache/static/client/js/main.js \
+    ./static/client/js/main.js
 COPY scripts ./scripts
-
 COPY manage.py ./manage.py
 COPY server ./server
 COPY client ./client
 COPY api ./api
-COPY static/client/js/ ./static/client/js/
 RUN chown -R apache:apache ./
 USER apache:apache
 RUN . env/bin/activate && echo yes | python3 manage.py collectstatic

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,7 +25,6 @@ COPY scripts/setup-venv.sh ./scripts/setup-venv.sh
 RUN apk add py3-pip python3 && sh ./scripts/setup-venv.sh
  
 FROM alpine:latest AS with-venv
-ARG LSC_VARIANT=local
 RUN apk add apache2 apache2-mod-wsgi bash tzdata nodejs aspell aspell-en
 SHELL [ "/bin/bash", "-c" ]
 RUN sed -i 's/localhost\/htdocs//' /etc/apache2/httpd.conf

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@
 # create a new docker image with each package.json update, which will
 # occupy hundreds of megabytes on your disk. This should only be used
 # in the CI/CD pipeline.
-ARG BUNDLE
+ARG BUNDLE=local
 
 FROM scratch AS local-bundle
 COPY ./static/client/js/main.js /var/www/apache/static/client/js/main.js

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+      args:
+        BUNDLE: local
     environment: *environment
     ports:
       - 8080:80


### PR DESCRIPTION
In order for the CD pipeline to be entirely self contained within docker, we need to create the javascript bundle in a docker managed buildstage. 