### PR TITLE
Fix bug associated with pushing to empty document

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -8,6 +8,9 @@ import json
 
 class ApiTester(TestCase):
     documents = {
+        'Empty Document 1' : {
+            'blocks' : []
+        },
         'Test Document 1' : {
             'blocks' : [
                 "This sentence haas two incorrect wrds"
@@ -127,6 +130,11 @@ class ApiTester(TestCase):
         self.assertEquals(data[3]['block_content'], 'Hello post world')
         self.assertEquals(len(data), 4)
 
+    def test_post_block_to_empty_document(self):
+        document = self.create_document_from_template('Empty Document 1')
+        response = self.client.post(reverse('api:block_view', args=(document.id, 0)))
+        self.assertEquals(response.status_code, 201)
+
     def test_document_blocks_have_correct_mistakes(self):
         document = self.create_document_from_template('Test Document 2')
         response = self.client.get(reverse('api:check_document_blocks', args=(document.id,)))
@@ -161,7 +169,4 @@ class ApiTester(TestCase):
         doc = self.client.get(reverse('api:get_documents'))
         data = doc.data
         self.assertEqual(data[0]['title'], 'New Title')
-                
-        
     
-        

--- a/api/views.py
+++ b/api/views.py
@@ -87,10 +87,11 @@ def block_view(request, pk, bo):
             )
             return Response(status=201)
         except Block.DoesNotExist:
-            blocks = Block.objects.filter(block_document=pk)
-            newest_block = blocks.aggregate(Max('block_order'))['block_order__max']
+            # Must account for the case where a block is posted to a
+            # document with no blocks so we use -1 as a fallback
+            newest_block = document.block_set.aggregate(Max('block_order'))['block_order__max'] or -1
             document.block_set.create(
-                block_order = (newest_block + 1),
+                block_order = newest_block + 1,
                 block_content = request.body.decode()
             )
             return Response(status=201)


### PR DESCRIPTION
We didn't handle the case where aggregating block orders with the max function yields `None`.