### PR TITLE
Use regex to match client paths

### DIFF
--- a/server/urls.py
+++ b/server/urls.py
@@ -1,7 +1,7 @@
-from django.urls import path, include
+from django.urls import path, include, re_path
 from api import views
 
 urlpatterns = [
     path('api/', include('api.urls')),
-    path('', include('client.urls'))
+    re_path('.*', include('client.urls'))
 ]


### PR DESCRIPTION
This should fix the bug where trying to access `localhost:8080/editor` produces a 404.