### PR TITLE
Chinaza/add missing document put endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,16 +1,17 @@
 from rest_framework import serializers
 from . import models
 
-class DocumentSerializer(serializers.ModelSerializer):
-    class Meta:
-        fields = ('id', 'title', 'created_at', 'updated_at',)
-        model = models.Document
-
 class BlockSerializer(serializers.ModelSerializer):
     class Meta:
-        fields = ('block_order', 'block_content')
+        fields = ('id', 'block_order', 'block_content')
         model = models.Block
 
+class DocumentSerializer(serializers.ModelSerializer):
+    blocks = BlockSerializer(source='block_set', many=True)
+    class Meta:
+        fields = ('id', 'title', 'created_at', 'updated_at', 'blocks')
+        model = models.Document
+        
 class MistakeSerializer(serializers.Serializer):
     word = serializers.CharField(max_length=200)
     start = serializers.IntegerField()
@@ -19,3 +20,41 @@ class MistakeSerializer(serializers.Serializer):
         child=serializers.CharField(max_length=200),
         allow_empty=True
     )
+
+    
+class PutDocumentSerializer(serializers.Serializer):
+    """
+    This serializer contains a the data that needs to be provided
+    by the frontend to update an existing document.
+    """
+    
+    class Block(serializers.ModelSerializer):
+        """
+        This represents a block that may or may not exist in the
+        database.
+        """
+        
+        id = serializers.IntegerField(required=False)
+        """
+        Blocks that exist in the database must have the ID field
+        provided explicitly. Blocks with no ID field are assumed to not
+        exist and will be created.
+        """
+        
+        class Meta:
+            model = models.Block
+            fields = ('id', 'block_order', 'block_content')
+            
+    title = serializers.CharField(required=False, max_length=200)
+    """
+    The new title to use for the document, if the title is to be
+    updated
+    """
+    
+    blocks = Block(required=False, many=True)
+    """
+    This represents the new blocks for a document, if the blocksp
+    are being updated.  If only the title is provided, the blocks are
+    left unchanged. If an empty list is provided, all blocks are
+    deleted.
+    """

--- a/api/tests.py
+++ b/api/tests.py
@@ -8,6 +8,9 @@ import json
 
 class ApiTester(TestCase):
     documents = {
+        'Empty Document 1' : {
+            'blocks' : []
+        },
         'Test Document 1' : {
             'blocks' : [
                 "This sentence haas two incorrect wrds"
@@ -127,6 +130,11 @@ class ApiTester(TestCase):
         self.assertEquals(data[3]['block_content'], 'Hello post world')
         self.assertEquals(len(data), 4)
 
+    def test_post_block_to_empty_document(self):
+        document = self.create_document_from_template('Empty Document 1')
+        response = self.client.post(reverse('api:block_view', args=(document.id, 0)))
+        self.assertEquals(response.status_code, 201)
+
     def test_document_blocks_have_correct_mistakes(self):
         document = self.create_document_from_template('Test Document 2')
         response = self.client.get(reverse('api:check_document_blocks', args=(document.id,)))
@@ -161,7 +169,4 @@ class ApiTester(TestCase):
         doc = self.client.get(reverse('api:get_documents'))
         data = doc.data
         self.assertEqual(data[0]['title'], 'New Title')
-                
-        
     
-        

--- a/api/tests.py
+++ b/api/tests.py
@@ -104,7 +104,7 @@ class ApiTester(TestCase):
         self.assertEquals(data[0]['block_content'], self.documents['Test Document 2']['blocks'][1])
         self.assertEquals(len(data), 1)
         response = self.client.delete(reverse('api:block_view', args=(document.id, 3,)))
-        self.assertEquals(response.status_code, 409)
+        self.assertEquals(response.status_code, 404)
 
     
     def test_replace_block(self):

--- a/api/views.py
+++ b/api/views.py
@@ -7,7 +7,9 @@ from .models import Document, Block
 from rest_framework.response import Response
 from rest_framework.request import Request
 from django.db.models import Max, F
-from .serializers import DocumentSerializer, BlockSerializer, MistakeSerializer
+from .serializers import (DocumentSerializer, BlockSerializer,
+                          MistakeSerializer, PutDocumentSerializer)
+from django.db import transaction
 
 class DocumentList(generics.ListAPIView):
     queryset = Document.objects.all()
@@ -27,12 +29,65 @@ def document_view(request, pk):
         document.delete()
         return Response(status=204)
     elif request.method == 'PUT':
+        document = Document.objects.get(id=pk)
+        serializer = PutDocumentSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+        # We want to be able to catch exceptions made by us and only us
+        class BadRequest(Exception):
+            pass
         try:
-            document.title = request.body.decode()
-            document.save()
-            return Response(status=201)
-        except IntegrityError:
-            return Response(status=400)
+            # We will temporarily violate the uniqueness of block
+            # document and block order in reconstructing the
+            # blocks of the document from the request, so we need
+            # to declare the follwing block as a transaction after
+            # which constraints will be satisfied again.
+            with transaction.atomic():
+                if serializer.data.get('title'):
+                    document.title = serializer.data['title']
+                    document.save()
+                if serializer.data.get('blocks'):
+                    # We delete all requests that are not present in
+                    # the request from the database
+                    blocks_in_request = [block['id'] for block in serializer.data['blocks'] \
+                                         if block.get('id') is not None]
+                    document.block_set.exclude(pk__in=blocks_in_request).delete()
+                    # Now, we reconstruct the document
+                    sorted_request_blocks = sorted(serializer.data['blocks'],
+                                                   key=lambda block: block['block_order'])
+                    blocks_to_create = []
+                    for block_order, request_block in enumerate(sorted_request_blocks):
+                        if block_order != request_block['block_order']:
+                            raise BadRequest("Block indices to not start at zero and increase one by one")
+                        if request_block.get('id'):
+                            # If the block exists in the database,
+                            # simply change its order. This may cause two
+                            # elements to have the same block order, but
+                            # this is fine as by the end of the for loop
+                            # there will be no duplicates. This is further
+                            # enforced by the database.
+                            block = get_object_or_404(Block, pk=request_block['id'])
+                            block.block_order = block_order
+                            block.block_content = request_block['block_content']
+                            block.save()
+                        else:
+                            # Otherwise, we schedule the creation of a
+                            # new block with the correct block order.
+                            blocks_to_create.append(
+                                Block(
+                                    block_document=document,
+                                    block_order=block_order,
+                                    block_content=request_block['block_content']
+                                )
+                            )
+                    # Here we create all necessary new blocks.
+                    Block.objects.bulk_create(blocks_to_create)
+        except Block.DoesNotExist as e:
+            return Response(str(e), status=404)
+        except BadRequest as e:
+            # Simply return our error type converted to a string
+            return Response(str(e), status=400)
+        return Response(DocumentSerializer(document).data, status=201)
 
 @api_view(['DELETE', 'PUT', 'POST'])
 def block_view(request, pk, bo):

--- a/api/views.py
+++ b/api/views.py
@@ -87,10 +87,11 @@ def block_view(request, pk, bo):
             )
             return Response(status=201)
         except Block.DoesNotExist:
-            blocks = Block.objects.filter(block_document=pk)
-            newest_block = blocks.aggregate(Max('block_order'))['block_order__max']
+            # Must account for the case where a block is posted to a
+            # document with no blocks so we use -1 as a fallback
+            newest_block = document.block_set.aggregate(Max('block_order'))['block_order__max'] or -1
             document.block_set.create(
-                block_order = (newest_block + 1),
+                block_order = newest_block + 1,
                 block_content = request.body.decode()
             )
             return Response(status=201)

--- a/scripts/managerc.py
+++ b/scripts/managerc.py
@@ -1,1 +1,2 @@
 from api.models import *
+from api.serializers import *


### PR DESCRIPTION
There is now a put endpoint that allows the contents of a document to be updated.

The behavior of this endpoint and the data schema it expects is described in `serializers.py` under the `PutDocumentSerializer` class.

This PR also includes tests to ensure that the update functionality actually works.