### PR TITLE
Allow documents to be cleared with empty block list

### DIFF
--- a/api/tests.py
+++ b/api/tests.py
@@ -245,5 +245,15 @@ class ApiTester(TestCase):
                                                      blocks.data[1] | {'block_order':(9+10)*2}]),
                                    content_type='application/json')
         self.assertEqual(response.status_code, 400)
-        self.assertEqual(old_blocks[0].block_order, 0)
         self.assertQuerysetEqual(document.block_set.all(), old_blocks)
+
+
+    def test_document_put_empty_blocks_deletes_all_blocks(self):
+        document = self.create_document_from_template('Test Document 2')
+        response = self.client.put(reverse('api:document_view',
+                                   args=(document.id,)),
+                                   data=dict(title=document.title,
+                                             blocks=[]),
+                                   content_type='application/json')
+        self.assertEqual(response.status_code, 201)
+        self.assertEquals(document.block_set.count(), 0)

--- a/api/views.py
+++ b/api/views.py
@@ -46,7 +46,7 @@ def document_view(request, pk):
                 if serializer.data.get('title'):
                     document.title = serializer.data['title']
                     document.save()
-                if serializer.data.get('blocks'):
+                if serializer.data.get('blocks') is not None:
                     # We delete all requests that are not present in
                     # the request from the database
                     blocks_in_request = [block['id'] for block in serializer.data['blocks'] \


### PR DESCRIPTION
To check whether a blocks key was provided I just evaluated the list, but empty lists are False in python, so the whole if statement was skipped.

I just updated it to actually check that the blocks key is not None and added some extra tests.