### PR TITLE
Make document post return structure, add new blocks/ REST endpoint

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -58,3 +58,8 @@ class PutDocumentSerializer(serializers.Serializer):
     left unchanged. If an empty list is provided, all blocks are
     deleted.
     """
+
+class PutBlockSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Block
+        fields = ('block_content',)

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,12 +1,14 @@
 from django.urls import path
-from .views import (check_document_blocks, DocumentList, document_view, block_view, add_documents)
+from .views import (check_document_blocks, DocumentList, document_view,
+                    BlockView, add_documents, document_block_view)
 
 app_name = 'api'
 
 urlpatterns = [
     path('document/', DocumentList.as_view(), name='get_documents'),
     path('document/<int:pk>', document_view, name='document_view'),
-    path('document/<int:pk>/<int:bo>', block_view, name='block_view'),
+    path('document/<int:pk>/<int:bo>', document_block_view, name='document_block_view'),
+    path('block/<int:pk>', BlockView.as_view(), name='block'),
     path('check/document/<int:pk>', check_document_blocks, name='check_document_blocks'),
     path('documents/', add_documents, name='add_documents')
 ]


### PR DESCRIPTION
This PR fixes some quality of life issues raised by max.

When you post a new document, the original document structure is now returned so you don't need to make another api request to get the document.

Another REST endpoint, `blocks/` has also been added for performing operations on blocks based on their ids rather than block orders. The idea is that the `document/pk/bo` endpoint is for accessing blocks in an order relative to the parent document, but the block endpoint will be used for direct updates / queries on blocks.