### PR TITLE
Fix routing errror where start page was given on api requests

### DIFF
--- a/client/urls.py
+++ b/client/urls.py
@@ -1,8 +1,8 @@
-from django.urls import path
+from django.urls import re_path
 from .views import serve_app
 
 app_name = 'client'
 
 urlpatterns = [
-    path('', serve_app, name='serve_app')
+    re_path('', serve_app),
 ]

--- a/server/urls.py
+++ b/server/urls.py
@@ -3,5 +3,5 @@ from api import views
 
 urlpatterns = [
     path('api/', include('api.urls')),
-    re_path(r'.*', include('client.urls'))
+    path('', include('client.urls'))
 ]


### PR DESCRIPTION
My 'fix' to the url routing actually made all API routes return the template index html file.

This patches that behavior.